### PR TITLE
fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 ### CSV import files
 
-- [C#, .Net](main/csharp.csv)
-- [Go](main/golang.csv)
-- [PHP](main/php.csv)
-- [Python](main/python.csv)
-- [Ruby](main/ruby.csv)
-- [Rust](main/rust.csv)
-- [IT & General Programming](main/it_programming.csv)
+- [C#, .Net](csharp.csv)
+- [Go](golang.csv)
+- [PHP](php.csv)
+- [Python](python.csv)
+- [Ruby](ruby.csv)
+- [Rust](rust.csv)
+- [IT & General Programming](it_programming.csv)
 
 If you want to add a new account or programming language, just open a pull request.


### PR DESCRIPTION
Readme links were returning 404 as they contained `main/main` 
e.g. `https://github.com/przemekperon/mastodon-it-lists/blob/main/main/golang.csv` 

Just a small PR to fix the links in the README.md file