### PR TITLE
Add slint project account

### DIFF
--- a/rust.csv
+++ b/rust.csv
@@ -103,6 +103,7 @@ Account address,Show boosts,Notify on new posts,Languages
 @rust@octodon.social,true,false,
 @Schneems@ruby.social,true,false,
 @seanmonstar@masto.ai,true,false,
+@slint@fosstodon.org,true,false,
 @sgrif@mastodon.social,true,false,
 @silwol@chaos.social,true,false,
 @soller@fosstodon.org,true,false,


### PR DESCRIPTION
This is the account of the Slint project. We do a UI crate in and for rust.

I did this as an extra PR as I am not sure what your policy on project accounts is.